### PR TITLE
Fix property access with never libhybris patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-media-hub (4.6.1+ubports) xenial; urgency=medium
+media-hub (4.6.2+0ubports1) xenial; urgency=medium
 
   * Imported to UBports
 

--- a/debian/usr.bin.media-hub-server
+++ b/debian/usr.bin.media-hub-server
@@ -67,7 +67,7 @@
   /{,android/}system/vendor/lib{,64}/**.so m,
 
   # attach_disconnected path
-  /dev/socket/property_service rw,
+  /{,dev/}socket/property_service rw,
 
   # Android logging triggered by platform. Can safely deny
   deny /dev/log_main w,


### PR DESCRIPTION
Newer versions of libhybris uses android's property impl, this changes the socket path
as this gets accessed on the android side of the lxc container