### PR TITLE
AppArmor: Allow reading media codec configuration from /vendor

### DIFF
--- a/debian/usr.bin.media-hub-server
+++ b/debian/usr.bin.media-hub-server
@@ -97,6 +97,7 @@
   owner /tmp/orcexec* m,
 
   /{,android/}system/etc/media_codecs*.xml r,
+  /{,android/}vendor/etc/media_codecs*.xml r,
   /etc/wildmidi/wildmidi.cfg r,
 
   # Allow read on all directories


### PR DESCRIPTION
Required by some Android 9.0 devices like the Pixel 3a.