### PR TITLE
Basic HTTP authorization header support

### DIFF
--- a/src/core/media/engine.h
+++ b/src/core/media/engine.h
@@ -76,8 +76,11 @@ public:
 
     virtual const core::Property<State>& state() const = 0;
 
-    virtual bool open_resource_for_uri(const core::ubuntu::media::Track::UriType& uri, bool do_pipeline_reset) = 0;
-    virtual bool open_resource_for_uri(const core::ubuntu::media::Track::UriType& uri, const Player::HeadersType&) = 0;
+    virtual bool open_resource_for_uri(const core::ubuntu::media::Track::UriType& uri,
+                               bool do_pipeline_reset) = 0;
+    virtual bool open_resource_for_uri(const core::ubuntu::media::Track::UriType& uri,
+                               const core::ubuntu::media::Player::HeadersType& headers,
+                               bool do_pipeline_reset) = 0;
     // Throws core::ubuntu::media::Player::Error::OutOfProcessBufferStreamingNotSupported if the implementation does not
     // support this feature.
     virtual void create_video_sink(uint32_t texture_id) = 0;

--- a/src/core/media/gstreamer/engine.cpp
+++ b/src/core/media/gstreamer/engine.cpp
@@ -436,9 +436,10 @@ const core::Property<media::Engine::State>& gstreamer::Engine::state() const
 }
 
 bool gstreamer::Engine::open_resource_for_uri(const media::Track::UriType& uri,
+                                              const core::ubuntu::media::Player::HeadersType& headers
                                               bool do_pipeline_reset)
 {
-    d->playbin.set_uri(uri, core::ubuntu::media::Player::HeadersType{}, do_pipeline_reset);
+    d->playbin.set_uri(uri, headers, do_pipeline_reset);
     return true;
 }
 

--- a/src/core/media/gstreamer/engine.cpp
+++ b/src/core/media/gstreamer/engine.cpp
@@ -436,7 +436,7 @@ const core::Property<media::Engine::State>& gstreamer::Engine::state() const
 }
 
 bool gstreamer::Engine::open_resource_for_uri(const media::Track::UriType& uri,
-                                              const core::ubuntu::media::Player::HeadersType& headers
+                                              const core::ubuntu::media::Player::HeadersType& headers,
                                               bool do_pipeline_reset)
 {
     d->playbin.set_uri(uri, headers, do_pipeline_reset);
@@ -444,9 +444,9 @@ bool gstreamer::Engine::open_resource_for_uri(const media::Track::UriType& uri,
 }
 
 bool gstreamer::Engine::open_resource_for_uri(const media::Track::UriType& uri,
-                                              const core::ubuntu::media::Player::HeadersType& headers)
+                                              bool do_pipeline_reset)
 {
-    d->playbin.set_uri(uri, headers);
+    d->playbin.set_uri(uri, core::ubuntu::media::Player::HeadersType{}, do_pipeline_reset);
     return true;
 }
 

--- a/src/core/media/gstreamer/engine.h
+++ b/src/core/media/gstreamer/engine.h
@@ -33,8 +33,11 @@ public:
 
     const core::Property<State>& state() const;
 
-    bool open_resource_for_uri(const core::ubuntu::media::Track::UriType& uri, bool do_pipeline_reset);
-    bool open_resource_for_uri(const core::ubuntu::media::Track::UriType& uri, const core::ubuntu::media::Player::HeadersType& headers);
+    bool open_resource_for_uri(const core::ubuntu::media::Track::UriType& uri,
+                               bool do_pipeline_reset);
+    bool open_resource_for_uri(const core::ubuntu::media::Track::UriType& uri,
+                               const core::ubuntu::media::Player::HeadersType& headers,
+                               bool do_pipeline_reset);
     void create_video_sink(uint32_t texture_id);
 
     // use_main_thread will set the pipeline's new state in the main thread context

--- a/src/core/media/gstreamer/playbin.cpp
+++ b/src/core/media/gstreamer/playbin.cpp
@@ -637,7 +637,7 @@ void gstreamer::Playbin::setup_source(GstElement *source)
             const std::string user = words[0];
             words.erase(words.begin());
             const std::string pass = boost::algorithm::join(words, ":");
-            
+
             if (g_object_class_find_property(G_OBJECT_GET_CLASS(source), "user-id") != NULL) {
                 g_object_set(source, "user-id", user.c_str(), NULL);
             }
@@ -647,7 +647,7 @@ void gstreamer::Playbin::setup_source(GstElement *source)
         }
         g_free(decoded_auth);
     }
-    
+
     MH_INFO("setup_source done");
 }
 

--- a/src/core/media/player_implementation.cpp
+++ b/src/core/media/player_implementation.cpp
@@ -834,7 +834,7 @@ media::video::Sink::Ptr media::PlayerImplementation<Parent>::create_gl_texture_v
 }
 
 template<typename Parent>
-bool media::PlayerImplementation<Parent>::open_uri(const Track::UriType& uri)
+bool media::PlayerImplementation<Parent>::open_uri(const Track::UriType& uri, const Player::HeadersType& headers)
 {
     d->track_list->reset();
 
@@ -846,7 +846,7 @@ bool media::PlayerImplementation<Parent>::open_uri(const Track::UriType& uri)
     }
 
     static const bool do_pipeline_reset = false;
-    const bool ret = d->engine->open_resource_for_uri(uri, do_pipeline_reset);
+    const bool ret = d->engine->open_resource_for_uri(uri, headers, do_pipeline_reset);
     // Don't set new track as the current track to play since we're calling open_resource_for_uri above
     static const bool make_current = false;
     d->track_list->add_track_with_uri_at(uri, media::TrackList::after_empty_track(), make_current);
@@ -855,9 +855,9 @@ bool media::PlayerImplementation<Parent>::open_uri(const Track::UriType& uri)
 }
 
 template<typename Parent>
-bool media::PlayerImplementation<Parent>::open_uri(const Track::UriType& uri, const Player::HeadersType& headers)
+bool media::PlayerImplementation<Parent>::open_uri(const Track::UriType& uri)
 {
-    return d->engine->open_resource_for_uri(uri, headers);
+    return open_uri(uri, Player::HeadersType{});
 }
 
 template<typename Parent>

--- a/src/core/media/track_list_implementation.h
+++ b/src/core/media/track_list_implementation.h
@@ -41,6 +41,9 @@ public:
 
     Track::UriType query_uri_for_track(const Track::Id& id);
     Track::MetaData query_meta_data_for_track(const Track::Id& id);
+    Player::HeadersType query_headers_for_track(const Track::Id& id);
+
+    void attach_headers_for_next_uri(const Player::HeadersType& headers);
 
     void add_track_with_uri_at(const Track::UriType& uri, const Track::Id& position, bool make_current);
     void add_tracks_with_uri_at(const ContainerURI& uris, const Track::Id& position);

--- a/tests/unit-tests/test-gstreamer-engine.cpp
+++ b/tests/unit-tests/test-gstreamer-engine.cpp
@@ -208,7 +208,8 @@ TEST(GStreamerEngine, setting_uri_and_audio_playback_with_http_headers_works)
                     std::ref(wst),
                     std::placeholders::_1));
 
-    EXPECT_TRUE(engine.open_resource_for_uri(test_audio_uri, headers));
+    static const bool do_pipeline_reset = false;
+    EXPECT_TRUE(engine.open_resource_for_uri(test_audio_uri, headers, do_pipeline_reset));
     static const bool use_main_context = true;
     EXPECT_TRUE(engine.play(use_main_context));
     EXPECT_TRUE(wst.wait_for_state_for(


### PR DESCRIPTION
Implement basic HTTP authorization by parsing the header and setting
user credentials for the GStreamer source accordingly.

Implementation details:

When playing media through QtMultimedia media-hub will enqueue it
through the track list first, adding the need for having HTTP headers
cached until use.

Since the track list is also part of the public API/MPRIS we can't just
extend it by changing the add_track method signature. Instead, since we
already have an OpenUriExtended DBus API not part of the MPRIS spec,
we set the headers right before the URI is added, so that the headers
are attached to their known track ID.