### PR TITLE
Revert "Support playing remote media"

### DIFF
--- a/src/core/media/gstreamer/playbin.h
+++ b/src/core/media/gstreamer/playbin.h
@@ -66,8 +66,6 @@ struct Playbin
                              GstElement *source,
                              gpointer user_data);
 
-    static void streams_changed(GstElement*, gpointer user_data);
-
     Playbin(const core::ubuntu::media::Player::PlayerKey key);
     ~Playbin();
 
@@ -102,8 +100,6 @@ struct Playbin
 
     void setup_source(GstElement *source);
 
-    void update_media_file_type();
-
     // Sets the pipeline state in the main thread context instead of the possibility of creating
     // a deadlock in the streaming thread
     static gboolean set_state_in_main_thread(gpointer user_data);
@@ -118,6 +114,10 @@ struct Playbin
     std::string file_info_from_uri(const std::string& uri) const;
     std::string encode_uri(const std::string& uri) const;
     std::string decode_uri(const std::string& uri) const;
+    std::string get_file_content_type(const std::string& uri) const;
+
+    bool is_audio_file(const std::string& uri) const;
+    bool is_video_file(const std::string& uri) const;
 
     MediaFileType media_file_type() const;
 
@@ -136,8 +136,6 @@ struct Playbin
     core::ubuntu::media::Player::Lifetime player_lifetime;
     gulong about_to_finish_handler_id;
     gulong source_setup_handler_id;
-    gulong audio_changed_handler_id;
-    gulong video_changed_handler_id;
     struct
     {
         core::Signal<void> about_to_finish;

--- a/src/core/media/player_skeleton.h
+++ b/src/core/media/player_skeleton.h
@@ -59,8 +59,6 @@ class PlayerSkeleton : public core::ubuntu::media::Player
         std::shared_ptr<core::dbus::Object> session;
         // The Service instance that manages Player instances
         core::ubuntu::media::Service* player_service;
-        // The asio service for async timers
-        boost::asio::io_service& io_service;
         // Our functional dependencies.
         apparmor::ubuntu::RequestContextResolver::Ptr request_context_resolver;
         apparmor::ubuntu::RequestAuthenticator::Ptr request_authenticator;

--- a/src/core/media/service_implementation.cpp
+++ b/src/core/media/service_implementation.cpp
@@ -194,7 +194,6 @@ std::shared_ptr<media::Player> media::ServiceImplementation::create_session(
             conf.service,
             conf.session,
             conf.player_service,
-            d->configuration.external_services.io_service,
             d->request_context_resolver,
             d->request_authenticator
         },


### PR DESCRIPTION
Reverts ubports/media-hub#15

This change has caused problems on many devices. It appears that playback of ringtones is broken on the E4.5 (https://github.com/ubports/ubuntu-touch/issues/1594) and Android9 devices (https://github.com/ubports/media-hub/commit/1d5e93809328e16239d1090fffaa0e650eff34b8#commitcomment-43979977). I've also received a report about ringtone playback breaking on the OnePlus 3T after installing the gst-droid patches, which would also install the new media-hub.

Since this patch was merged incorrectly *anyway* (it should be multiple commits instead of one squashed commit), revert it while waiting for a fixed version.