### PR TITLE
Support playing remote media

### DIFF
--- a/src/core/media/gstreamer/engine.cpp
+++ b/src/core/media/gstreamer/engine.cpp
@@ -83,6 +83,12 @@ struct gstreamer::Engine::Private
                 playbin.reset();
                 const media::Player::Error e = media::Player::Error::format_error;
                 error(e);
+#if 0
+            } else if (status == media::Player::PlaybackStatus::paused &&
+                       (state == Engine::State::ready || state == Engine::State::stopped)) {
+                MH_DEBUG("######################################################################");
+                MH_DEBUG("ignoring paused state while setup");
+#endif
             } else {
                 playback_status_changed(status);
             }

--- a/src/core/media/gstreamer/playbin.cpp
+++ b/src/core/media/gstreamer/playbin.cpp
@@ -48,8 +48,10 @@ void gstreamer::Playbin::setup_video_sink_for_buffer_streaming()
     GstContext *context;
     GstStructure *structure;
 
+    MH_DEBUG("");
     switch (backend) {
     case core::ubuntu::media::AVBackend::Backend::hybris:
+        MH_DEBUG("hybris backend");
         // Get the service-side BufferQueue (IGraphicBufferProducer) and
         // associate with it the SurfaceTextureClientHybris instance.
         igbp = decoding_service_get_igraphicbufferproducer();
@@ -66,6 +68,7 @@ void gstreamer::Playbin::setup_video_sink_for_buffer_streaming()
         gst_element_set_context(pipeline, context);
         break;
     case core::ubuntu::media::AVBackend::Backend::mir:
+        MH_DEBUG("mir backend");
         // Connect to buffer consumer socket
         connect_to_consumer();
         // Configure mirsink so it exports buffers (otherwise it would create
@@ -74,6 +77,7 @@ void gstreamer::Playbin::setup_video_sink_for_buffer_streaming()
         break;
     case core::ubuntu::media::AVBackend::Backend::none:
     default:
+        MH_DEBUG("none backend");
         throw core::ubuntu::media::Player::Errors::
             OutOfProcessBufferStreamingNotSupported{};
     }
@@ -445,6 +449,7 @@ void gstreamer::Playbin::setup_pipeline_for_audio_video()
     flags &= ~GST_PLAY_FLAG_TEXT;
     g_object_set (pipeline, "flags", flags, nullptr);
 
+    MH_DEBUG("flags: %x", flags);
     const char *asink_name = ::getenv("CORE_UBUNTU_MEDIA_SERVICE_AUDIO_SINK_NAME");
 
     if (asink_name == nullptr)
@@ -464,6 +469,7 @@ void gstreamer::Playbin::setup_pipeline_for_audio_video()
         else if (backend == core::ubuntu::media::AVBackend::Backend::mir)
             vsink_name = MIR_SINK;
     }
+    MH_DEBUG("vsink_name: %s", vsink_name);
 
     if (vsink_name) {
         video_sink_name = vsink_name;
@@ -613,6 +619,8 @@ void gstreamer::Playbin::set_uri(
          * inspect the media and report the number of audio and video streams
          */
         set_state_and_wait(GST_STATE_PAUSED, true);
+        set_state_and_wait(GST_STATE_READY, true);
+        //gst_element_set_state(pipeline, GST_STATE_READY);
     }
 
     request_headers = headers;

--- a/src/core/media/gstreamer/playbin.cpp
+++ b/src/core/media/gstreamer/playbin.cpp
@@ -118,6 +118,16 @@ void gstreamer::Playbin::source_setup(GstElement*,
     static_cast<Playbin*>(user_data)->setup_source(source);
 }
 
+void gstreamer::Playbin::streams_changed(GstElement *pipeline,
+                                         gpointer /*user_data*/)
+{
+    /* We are possibly in a GStreamer working thread, so we notify the main
+     * thread of this event through a message in the bus */
+    gst_element_post_message(pipeline,
+        gst_message_new_application(GST_OBJECT(pipeline),
+            gst_structure_new_empty("streams-changed")));
+}
+
 gstreamer::Playbin::Playbin(const core::ubuntu::media::Player::PlayerKey key_in)
     : pipeline(gst_element_factory_make("playbin", pipeline_name().c_str())),
       bus{gst_element_get_bus(pipeline)},
@@ -167,6 +177,20 @@ gstreamer::Playbin::Playbin(const core::ubuntu::media::Player::PlayerKey key_in)
         G_CALLBACK(source_setup),
         this
         );
+
+    audio_changed_handler_id = g_signal_connect(
+        pipeline,
+        "audio-changed",
+        G_CALLBACK(streams_changed),
+        this
+        );
+
+    video_changed_handler_id = g_signal_connect(
+        pipeline,
+        "video-changed",
+        G_CALLBACK(streams_changed),
+        this
+        );
 }
 
 // Note that we might be accessing freed memory here, so activate DEBUG_REFS
@@ -195,6 +219,8 @@ gstreamer::Playbin::~Playbin()
 
     g_signal_handler_disconnect(pipeline, about_to_finish_handler_id);
     g_signal_handler_disconnect(pipeline, source_setup_handler_id);
+    g_signal_handler_disconnect(pipeline, audio_changed_handler_id);
+    g_signal_handler_disconnect(pipeline, video_changed_handler_id);
 
     if (pipeline)
         gst_object_unref(pipeline);
@@ -310,6 +336,10 @@ void gstreamer::Playbin::process_message_element(GstMessage *message)
     {
         send_frame_ready();
     }
+    else if (g_strcmp0("streams-changed", struct_name) == 0)
+    {
+        update_media_file_type();
+    }
     else
     {
         MH_ERROR("Unknown GST_MESSAGE_ELEMENT with struct %s", struct_name);
@@ -336,6 +366,7 @@ void gstreamer::Playbin::on_new_message_async(const Bus::Message& message)
         }
         signals.on_state_changed(std::make_pair(message.detail.state_changed, message.source));
         break;
+    case GST_MESSAGE_APPLICATION:
     case GST_MESSAGE_ELEMENT:
         if (gst_is_missing_plugin_message(message.message))
             process_missing_plugin_message(message.message);
@@ -551,10 +582,12 @@ void gstreamer::Playbin::set_uri(
     }
 
     g_object_set(pipeline, "uri", tmp_uri.c_str(), NULL);
-    if (is_video_file(tmp_uri))
-        file_type = MEDIA_FILE_TYPE_VIDEO;
-    else if (is_audio_file(tmp_uri))
-        file_type = MEDIA_FILE_TYPE_AUDIO;
+    if (!tmp_uri.empty()) {
+        /* Setting the pipeline to "paused" (a.k.a. "ready") to let GStreamer
+         * inspect the media and report the number of audio and video streams
+         */
+        set_state_and_wait(GST_STATE_PAUSED, true);
+    }
 
     request_headers = headers;
 
@@ -581,6 +614,20 @@ void gstreamer::Playbin::setup_source(GstElement *source)
             g_object_set(source, "user-agent", request_headers["User-Agent"].c_str(), NULL);
         }
     }
+}
+
+void gstreamer::Playbin::update_media_file_type()
+{
+    int videoStreamCount = 0, audioStreamCount = 0;
+    g_object_get(pipeline, "n-video", &videoStreamCount, NULL);
+    g_object_get(pipeline, "n-audio", &audioStreamCount, NULL);
+    MH_DEBUG("streams changed: file has %d video streams and %d audio streams",
+             videoStreamCount, audioStreamCount);
+
+    if (videoStreamCount > 0)
+        file_type = MEDIA_FILE_TYPE_VIDEO;
+    else if (audioStreamCount > 0)
+        file_type = MEDIA_FILE_TYPE_AUDIO;
 }
 
 std::string gstreamer::Playbin::uri() const
@@ -857,53 +904,6 @@ std::string gstreamer::Playbin::decode_uri(const std::string& uri) const
     const std::string decoded{decoded_gchar};
     g_free(decoded_gchar);
     return decoded;
-}
-
-std::string gstreamer::Playbin::get_file_content_type(const std::string& uri) const
-{
-    if (uri.empty())
-        return std::string();
-
-    const std::string encoded_uri{encode_uri(uri)};
-
-    const std::string content_type {file_info_from_uri(encoded_uri)};
-    if (content_type.empty())
-    {
-        MH_WARNING("Failed to get actual track content type");
-        return std::string("audio/video/");
-    }
-
-    MH_INFO("Found content type: %s", content_type);
-
-    return content_type;
-}
-
-bool gstreamer::Playbin::is_audio_file(const std::string& uri) const
-{
-    if (uri.empty())
-        return false;
-
-    if (get_file_content_type(uri).find("audio/") == 0)
-    {
-        MH_INFO("Found audio content");
-        return true;
-    }
-
-    return false;
-}
-
-bool gstreamer::Playbin::is_video_file(const std::string& uri) const
-{
-    if (uri.empty())
-        return false;
-
-    if (get_file_content_type(uri).find("video/") == 0)
-    {
-        MH_INFO("Found video content");
-        return true;
-    }
-
-    return false;
 }
 
 gstreamer::Playbin::MediaFileType gstreamer::Playbin::media_file_type() const

--- a/src/core/media/gstreamer/playbin.cpp
+++ b/src/core/media/gstreamer/playbin.cpp
@@ -679,8 +679,10 @@ gboolean gstreamer::Playbin::set_state_in_main_thread(gpointer user_data)
 {
     MH_TRACE("");
     auto thiz = static_cast<Playbin*>(user_data);
-    if (thiz and thiz->pipeline)
+    if (thiz and thiz->pipeline) {
         gst_element_set_state(thiz->pipeline, thiz->current_new_state);
+        MH_TRACE("state set to %d", thiz->current_new_state);
+    }
 
     // Always return false so this is a single shot function call
     return false;
@@ -706,11 +708,14 @@ bool gstreamer::Playbin::set_state_and_wait(GstState new_state, bool use_main_th
         MH_DEBUG("Requested state change in main thread context.");
 
         GstState current, pending;
-        result = GST_STATE_CHANGE_SUCCESS == gst_element_get_state(
+        GstStateChangeReturn ret = gst_element_get_state(
                 pipeline,
                 &current,
                 &pending,
                 state_change_timeout.count());
+        MH_DEBUG("gst_element_get_state returned %d, current = %d, pending = %d",
+                 ret, current, pending);
+        result = (ret == GST_STATE_CHANGE_SUCCESS);
     }
     else
     {

--- a/src/core/media/gstreamer/playbin.h
+++ b/src/core/media/gstreamer/playbin.h
@@ -66,6 +66,8 @@ struct Playbin
                              GstElement *source,
                              gpointer user_data);
 
+    static void streams_changed(GstElement*, gpointer user_data);
+
     Playbin(const core::ubuntu::media::Player::PlayerKey key);
     ~Playbin();
 
@@ -100,6 +102,8 @@ struct Playbin
 
     void setup_source(GstElement *source);
 
+    void update_media_file_type();
+
     // Sets the pipeline state in the main thread context instead of the possibility of creating
     // a deadlock in the streaming thread
     static gboolean set_state_in_main_thread(gpointer user_data);
@@ -114,10 +118,6 @@ struct Playbin
     std::string file_info_from_uri(const std::string& uri) const;
     std::string encode_uri(const std::string& uri) const;
     std::string decode_uri(const std::string& uri) const;
-    std::string get_file_content_type(const std::string& uri) const;
-
-    bool is_audio_file(const std::string& uri) const;
-    bool is_video_file(const std::string& uri) const;
 
     MediaFileType media_file_type() const;
 
@@ -136,6 +136,8 @@ struct Playbin
     core::ubuntu::media::Player::Lifetime player_lifetime;
     gulong about_to_finish_handler_id;
     gulong source_setup_handler_id;
+    gulong audio_changed_handler_id;
+    gulong video_changed_handler_id;
     struct
     {
         core::Signal<void> about_to_finish;

--- a/src/core/media/gstreamer/playbin.h
+++ b/src/core/media/gstreamer/playbin.h
@@ -167,6 +167,7 @@ private:
     void send_buffer_data(int fd, void *data, size_t len);
     void send_frame_ready(void);
     void process_missing_plugin_message(GstMessage *message);
+    void process_video_sink_state_changed(Bus::Message::Detail::StateChanged state);
 
     const core::ubuntu::media::Player::PlayerKey key;
     const core::ubuntu::media::AVBackend::Backend backend;

--- a/src/core/media/player_implementation.cpp
+++ b/src/core/media/player_implementation.cpp
@@ -190,8 +190,11 @@ struct media::PlayerImplementation<Parent>::Private :
     {
         return [this](const media::Player::PlaybackStatus& status)
         {
-            MH_INFO("Emiting playback_status_changed signal: %s", status);
-            parent->emit_playback_status_changed(status);
+            const auto n_tracks = track_list->tracks()->size();
+            if (n_tracks > 0) {
+                MH_INFO("Emitting playback_status_changed signal: %s", status);
+                parent->emit_playback_status_changed(status);
+            }
         };
     }
 
@@ -373,7 +376,9 @@ struct media::PlayerImplementation<Parent>::Private :
         media::Track::MetaData metadata{md};
         if (not metadata.is_set(media::Track::MetaData::TrackIdKey))
         {
-            const std::string current_track = track_list->current();
+            const auto n_tracks = track_list->tracks()->size();
+            const std::string current_track =
+                n_tracks > 0 ? track_list->current() : std::string();
             if (not current_track.empty())
             {
                 const std::size_t last_slash = current_track.find_last_of("/");

--- a/src/core/media/player_implementation.cpp
+++ b/src/core/media/player_implementation.cpp
@@ -660,8 +660,7 @@ media::PlayerImplementation<Parent>::PlayerImplementation(const media::PlayerImp
 
     d->track_list->on_end_of_tracklist().connect([this]()
     {
-        if (d->engine->state() != gstreamer::Engine::State::ready
-                && d->engine->state() != gstreamer::Engine::State::stopped)
+        if (d->engine->state() != gstreamer::Engine::State::stopped)
         {
             MH_INFO("End of tracklist reached, stopping playback");
             const constexpr bool use_main_thread = true;

--- a/src/core/media/player_skeleton.cpp
+++ b/src/core/media/player_skeleton.cpp
@@ -42,6 +42,9 @@
 #include <core/dbus/asio/executor.h>
 #include <core/dbus/interfaces/properties.h>
 
+#include <chrono>
+#include <boost/asio/steady_timer.hpp>
+
 namespace dbus = core::dbus;
 namespace media = core::ubuntu::media;
 
@@ -50,6 +53,7 @@ struct media::PlayerSkeleton::Private
     Private(media::PlayerSkeleton* player,
             const std::shared_ptr<core::dbus::Bus>& bus,
             const std::shared_ptr<core::dbus::Object>& session,
+            boost::asio::io_service& io_service,
             const apparmor::ubuntu::RequestContextResolver::Ptr& request_context_resolver,
             const apparmor::ubuntu::RequestAuthenticator::Ptr& request_authenticator)
         : impl(player),
@@ -67,7 +71,8 @@ struct media::PlayerSkeleton::Private
               skeleton.signals.playback_status_changed,
               skeleton.signals.video_dimension_changed,
               skeleton.signals.error,
-              skeleton.signals.buffering_changed
+              skeleton.signals.buffering_changed,
+              io_service,
           }
     {
     }
@@ -315,7 +320,9 @@ struct media::PlayerSkeleton::Private
                 const std::shared_ptr<DBusPlaybackStatusChangedSignal>& remote_playback_status_changed,
                 const std::shared_ptr<DBusVideoDimensionChangedSignal>& remote_video_dimension_changed,
                 const std::shared_ptr<DBusErrorSignal>& remote_error,
-                const std::shared_ptr<DBusBufferingChangedSignal>& remote_buffering_changed)
+                const std::shared_ptr<DBusBufferingChangedSignal>& remote_buffering_changed,
+                boost::asio::io_service& io_service)
+            : buffering_signal_timeout(io_service)
         {
             seeked_to.connect([remote_seeked](std::uint64_t value)
             {
@@ -347,9 +354,32 @@ struct media::PlayerSkeleton::Private
                 remote_error->emit(e);
             });
 
-            buffering_changed.connect([remote_buffering_changed](int value)
+            buffering_changed.connect([this, remote_buffering_changed](int value)
             {
-                remote_buffering_changed->emit(value);
+                auto now = std::chrono::steady_clock::now();
+                auto time_since_last_emission = now - buffering_signal_last_emission;
+                if (value >= 100 ||
+                    time_since_last_emission > std::chrono::milliseconds(500)) {
+                    // Send the signal immediately
+                    buffering_signal_timeout.cancel();
+                    buffering_signal_value = -1;
+                    remote_buffering_changed->emit(value);
+                    buffering_signal_last_emission = now;
+                } else {
+                    if (buffering_signal_value < 0) {
+                        auto next_emission_time = buffering_signal_last_emission + std::chrono::milliseconds(500);
+                        buffering_signal_timeout.expires_at(next_emission_time);
+                        buffering_signal_timeout.async_wait(
+                            [this, remote_buffering_changed](const boost::system::error_code& ec) {
+                            if (ec == boost::asio::error::operation_aborted)
+                                return;
+                            remote_buffering_changed->emit(buffering_signal_value);
+                            buffering_signal_last_emission = std::chrono::steady_clock::now();
+                            buffering_signal_value = -1;
+                        });
+                    }
+                    buffering_signal_value = value;
+                }
             });
 
         }
@@ -361,12 +391,15 @@ struct media::PlayerSkeleton::Private
         core::Signal<media::video::Dimensions> video_dimension_changed;
         core::Signal<media::Player::Error> error;
         core::Signal<int> buffering_changed;
+        boost::asio::steady_timer buffering_signal_timeout;
+        std::chrono::steady_clock::time_point buffering_signal_last_emission;
+        int buffering_signal_value = -1;
     } signals;
 
 };
 
 media::PlayerSkeleton::PlayerSkeleton(const media::PlayerSkeleton::Configuration& config)
-        : d(new Private{this, config.bus, config.session, config.request_context_resolver, config.request_authenticator})
+        : d(new Private{this, config.bus, config.session, config.io_service, config.request_context_resolver, config.request_authenticator})
 {
     // Setup method handlers for mpris::Player methods.
     auto next = std::bind(&Private::handle_next, d, std::placeholders::_1);

--- a/src/core/media/player_skeleton.h
+++ b/src/core/media/player_skeleton.h
@@ -59,6 +59,8 @@ class PlayerSkeleton : public core::ubuntu::media::Player
         std::shared_ptr<core::dbus::Object> session;
         // The Service instance that manages Player instances
         core::ubuntu::media::Service* player_service;
+        // The asio service for async timers
+        boost::asio::io_service& io_service;
         // Our functional dependencies.
         apparmor::ubuntu::RequestContextResolver::Ptr request_context_resolver;
         apparmor::ubuntu::RequestAuthenticator::Ptr request_authenticator;

--- a/src/core/media/service_implementation.cpp
+++ b/src/core/media/service_implementation.cpp
@@ -194,6 +194,7 @@ std::shared_ptr<media::Player> media::ServiceImplementation::create_session(
             conf.service,
             conf.session,
             conf.player_service,
+            d->configuration.external_services.io_service,
             d->request_context_resolver,
             d->request_authenticator
         },

--- a/tests/unit-tests/test-gstreamer-engine.cpp
+++ b/tests/unit-tests/test-gstreamer-engine.cpp
@@ -181,9 +181,9 @@ TEST(GStreamerEngine, setting_uri_and_audio_playback_with_http_headers_works)
               headers[conn->http_headers[i].name].insert(conn->http_headers[i].value);
             }
 
-            EXPECT_TRUE(headers.at("User-Agent").count("MediaHub") == 1);
-            EXPECT_TRUE(headers.at("Cookie").count("A=B") == 1);
-            EXPECT_TRUE(headers.at("Cookie").count("X=Y") == 1);
+            EXPECT_EQ(headers.at("User-Agent").count("MediaHub"), 1);
+            EXPECT_EQ(headers.at("Cookie").count("A=B"), 1);
+            EXPECT_EQ(headers.at("Cookie").count("X=Y"), 1);
 
             mg_send_file(conn, test_file.c_str(), 0);
             return MG_MORE;


### PR DESCRIPTION
Restore the branch. A small change has been added to trigger the detection of the audio and video streams, and a new commit to ensure that this does not cause further propagation of internal events.