### PR TITLE
Allow the playbin object from the gstreamer backend to be configured.

### DIFF
--- a/debian/media-hub.conf
+++ b/debian/media-hub.conf
@@ -6,4 +6,16 @@ stop on runlevel [06]
 respawn
 respawn limit unlimited
 
-exec media-hub-server
+script
+
+  # load user config
+  export env USERNAME=`id -un`
+  export env USERCONFIG=/home/$USERNAME/.config/media-hub/media-hub.conf
+
+  if [ -e $USERCONFIG ]; then
+    . $USERCONFIG
+  fi
+
+  exec media-hub-server
+
+end script

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,3 +37,16 @@ After this, files in Music or Videos folders can be played:
 ```text
 $ mediaplayer-app Music/file.mp3
 ```
+
+## Configure gstreamer1.0 backend
+
+Some properties of the playbin object can be configured by creating a file in $HOME/.config/media-hub/media-hub.conf containing:
+```text
+# Playbin buffer-duration, in nano seconds, or 0 to disble
+export PLAYBIN_BUFFER_DURATION=5000000000
+# Playbin buffer-size, in bytes or 0 to disable
+export PLAYBIN_BUFFER_SIZE=0
+# Additional flags. See GstPlayFlags
+# 0x100: Enable buffering
+export PLAYBIN_ADDITIONAL_FLAGS=0x100
+```

--- a/src/core/media/gstreamer/playbin.cpp
+++ b/src/core/media/gstreamer/playbin.cpp
@@ -413,11 +413,36 @@ gstreamer::Bus& gstreamer::Playbin::message_bus()
 void gstreamer::Playbin::setup_pipeline_for_audio_video()
 {
     gint flags;
+    char * playbin_env_var;
+
+
     g_object_get (pipeline, "flags", &flags, nullptr);
     flags |= GST_PLAY_FLAG_AUDIO;
     flags |= GST_PLAY_FLAG_VIDEO;
     flags &= ~GST_PLAY_FLAG_TEXT;
+
+    playbin_env_var = ::getenv("PLAYBIN_ADDITIONAL_FLAGS");
+    if (playbin_env_var != nullptr) {
+        const unsigned int playbin_additional_flags = strtol(playbin_env_var, nullptr, 0);
+        MH_INFO(" adding playbin flags 0x%X", playbin_additional_flags);
+        flags |= playbin_additional_flags;
+    }
+
     g_object_set (pipeline, "flags", flags, nullptr);
+
+    playbin_env_var = ::getenv("PLAYBIN_BUFFER_SIZE");
+    if (playbin_env_var != nullptr) {
+        const int playbin_buffer_size = strtol(playbin_env_var, nullptr, 0);
+        MH_INFO(" setting playbin buffer-size to %d", playbin_buffer_size);
+        g_object_set (pipeline, "buffer-size", playbin_buffer_size, nullptr);
+    }
+
+    playbin_env_var = ::getenv("PLAYBIN_BUFFER_DURATION");
+    if (playbin_env_var != nullptr) {
+        const long long playbin_buffer_duration = strtoll(playbin_env_var, nullptr, 0);
+        MH_INFO(" setting playbin buffer-duration to %lld", playbin_buffer_duration);
+        g_object_set (pipeline, "buffer-duration", playbin_buffer_duration, nullptr);
+    }
 
     const char *asink_name = ::getenv("CORE_UBUNTU_MEDIA_SERVICE_AUDIO_SINK_NAME");
 


### PR DESCRIPTION
Configurable properties: buffer-size, buffer-duration and flags.

The configuration of these properties can be done in a file:
  .config/media-hub/media-hub.conf

This allows to try to reduce stuttering of high bitrate media
(for example for playing flac audio see https://github.com/ubports/ubuntu-touch/issues/1423).