### PR TITLE
WIP add equalizer

### DIFF
--- a/include/core/media/player.h
+++ b/include/core/media/player.h
@@ -169,6 +169,7 @@ class Player : public std::enable_shared_from_this<Player>
     virtual void pause() = 0;
     virtual void stop() = 0;
     virtual void seek_to(const std::chrono::microseconds& offset) = 0;
+    virtual void equalizer_set_band(int band, double gain) = 0;
 
     virtual const core::Property<bool>& can_play() const = 0;
     virtual const core::Property<bool>& can_pause() const = 0;

--- a/include/core/media/service.h
+++ b/include/core/media/service.h
@@ -20,6 +20,7 @@
 
 #include <core/media/player.h>
 
+#include <map>
 #include <memory>
 
 namespace core
@@ -62,6 +63,9 @@ class Service : public std::enable_shared_from_this<Service>
 
     /** @brief Pauses sessions other than the supplied one. */
     virtual void pause_other_sessions(Player::PlayerKey) = 0;
+
+    /** @brief Set equalizer band for all multimedia players. */
+    virtual std::map<int, double>& equalizer_get_bands() = 0;
 
     /** @brief Set equalizer band for all multimedia players. */
     virtual void equalizer_set_band(int band, double gain) = 0;

--- a/include/core/media/service.h
+++ b/include/core/media/service.h
@@ -63,6 +63,9 @@ class Service : public std::enable_shared_from_this<Service>
     /** @brief Pauses sessions other than the supplied one. */
     virtual void pause_other_sessions(Player::PlayerKey) = 0;
 
+    /** @brief Set equalizer band for all multimedia players. */
+    virtual void equalizer_set_band(int band, double gain) = 0;
+
     /** @brief Signals when the media-hub server disappears from the bus **/
     virtual const core::Signal<void>& service_disconnected() const = 0;
     /** @brief Signals when the media-hub server reappears from the bus **/

--- a/include/core/media/service.h
+++ b/include/core/media/service.h
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <memory>
+#include <tuple>
 
 namespace core
 {
@@ -32,6 +33,9 @@ namespace media
 class Service : public std::enable_shared_from_this<Service>
 {
   public:
+
+    typedef std::tuple<int, double> EqualizerBand;
+
     struct Client
     {
         static const std::shared_ptr<Service> instance();
@@ -66,9 +70,10 @@ class Service : public std::enable_shared_from_this<Service>
 
     /** @brief Set equalizer band for all multimedia players. */
     virtual std::map<int, double>& equalizer_get_bands() = 0;
-
     /** @brief Set equalizer band for all multimedia players. */
     virtual void equalizer_set_band(int band, double gain) = 0;
+    /** @brief Signals when an equalizer band changes **/
+    virtual const core::Signal<EqualizerBand>& equalizer_band_changed() const = 0;
 
     /** @brief Signals when the media-hub server disappears from the bus **/
     virtual const core::Signal<void>& service_disconnected() const = 0;

--- a/src/core/media/engine.h
+++ b/src/core/media/engine.h
@@ -86,6 +86,7 @@ public:
     virtual bool stop(bool use_main_context = false)  = 0;
     virtual bool pause() = 0;
     virtual bool seek_to(const std::chrono::microseconds& ts) = 0;
+    virtual void equalizer_set_band(int band, double gain) = 0;
 
     virtual const core::Property<bool>& is_video_source() const = 0;
     virtual const core::Property<bool>& is_audio_source() const = 0;

--- a/src/core/media/gstreamer/engine.cpp
+++ b/src/core/media/gstreamer/engine.cpp
@@ -626,3 +626,9 @@ void gstreamer::Engine::reset()
 {
     d->playbin.reset();
 }
+
+void gstreamer::Engine::equalizer_set_band(int band, double gain) 
+{
+    d->playbin.equalizer_set_band(band, gain);
+}
+

--- a/src/core/media/gstreamer/engine.h
+++ b/src/core/media/gstreamer/engine.h
@@ -42,6 +42,7 @@ public:
     bool stop(bool use_main_thread = false);
     bool pause();
     bool seek_to(const std::chrono::microseconds& ts);
+    void equalizer_set_band(int band, double gain);
 
     const core::Property<bool>& is_video_source() const;
     const core::Property<bool>& is_audio_source() const;

--- a/src/core/media/gstreamer/playbin.cpp
+++ b/src/core/media/gstreamer/playbin.cpp
@@ -1063,8 +1063,8 @@ void gstreamer::Playbin::equalizer_set_band(int band, double gain)
     else if(band < 0)
         band = 0;
 
-    if(gain > 24.0)
-        gain = 24.0;
+    if(gain > 12.0)
+        gain = 12.0;
     else if(gain < -24.0)
         gain = -24.0;
 

--- a/src/core/media/gstreamer/playbin.h
+++ b/src/core/media/gstreamer/playbin.h
@@ -107,6 +107,7 @@ struct Playbin
     // pipeline's new_state in the main thread context.
     bool set_state_and_wait(GstState new_state, bool use_main_thread = false);
     bool seek(const std::chrono::microseconds& ms);
+    void equalizer_set_band(int band, double gain);
 
     core::ubuntu::media::video::Dimensions get_video_dimensions() const;
     void emit_video_dimensions_changed_if_changed(const core::ubuntu::media::video::Dimensions &new_dimensions);
@@ -128,6 +129,7 @@ struct Playbin
     MediaFileType file_type;
     GstElement* video_sink;
     GstElement* audio_sink;
+    GstElement* equalizer;
     core::Connection on_new_message_connection_async;
     bool is_seeking;
     mutable uint64_t previous_position;

--- a/src/core/media/mpris/service.h
+++ b/src/core/media/mpris/service.h
@@ -140,6 +140,7 @@ struct Service
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(CreateFixedSession, Service, 1000)
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(ResumeSession, Service, 1000)
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(PauseOtherSessions, Service, 1000)
+    DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(EqualizerGetBands, Service, 1000)
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(EqualizerSetBand, Service, 1000)
 };
 }

--- a/src/core/media/mpris/service.h
+++ b/src/core/media/mpris/service.h
@@ -119,6 +119,18 @@ struct Service
                 return s;
             }
         };
+
+        struct EqualizerSetBand
+        {
+            static const std::string& name()
+            {
+                static const std::string s
+                {
+                    "core.ubuntu.media.Service.Error.EqualizerSetBand"
+                };
+                return s;
+            }
+        };
     };
 
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(CreateSession, Service, 1000)
@@ -128,6 +140,7 @@ struct Service
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(CreateFixedSession, Service, 1000)
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(ResumeSession, Service, 1000)
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(PauseOtherSessions, Service, 1000)
+    DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(EqualizerSetBand, Service, 1000)
 };
 }
 

--- a/src/core/media/mpris/service.h
+++ b/src/core/media/mpris/service.h
@@ -20,6 +20,7 @@
 #define MPRIS_SERVICE_H_
 
 #include <core/dbus/macros.h>
+#include <core/media/service.h>
 
 #include <chrono>
 #include <string>
@@ -142,6 +143,11 @@ struct Service
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(PauseOtherSessions, Service, 1000)
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(EqualizerGetBands, Service, 1000)
     DBUS_CPP_METHOD_WITH_TIMEOUT_DEF(EqualizerSetBand, Service, 1000)
+
+    struct Signals
+    {
+        DBUS_CPP_SIGNAL_DEF(EqualizerBandChanged, Service, core::ubuntu::media::Service::EqualizerBand)
+    };
 };
 }
 

--- a/src/core/media/player_implementation.cpp
+++ b/src/core/media/player_implementation.cpp
@@ -913,6 +913,12 @@ void media::PlayerImplementation<Parent>::seek_to(const std::chrono::microsecond
 }
 
 template<typename Parent>
+void media::PlayerImplementation<Parent>::equalizer_set_band(int band, double gain) 
+{
+    d->engine->equalizer_set_band(band, gain);
+}
+
+template<typename Parent>
 const core::Signal<>& media::PlayerImplementation<Parent>::on_client_disconnected() const
 {
     return d->on_client_disconnected;

--- a/src/core/media/player_implementation.h
+++ b/src/core/media/player_implementation.h
@@ -72,6 +72,7 @@ public:
     virtual void pause();
     virtual void stop();
     virtual void seek_to(const std::chrono::microseconds& offset);
+    virtual void equalizer_set_band(int band, double gain);
 
     const core::Signal<>& on_client_disconnected() const;
 

--- a/src/core/media/player_stub.cpp
+++ b/src/core/media/player_stub.cpp
@@ -374,6 +374,12 @@ void media::PlayerStub::seek_to(const std::chrono::microseconds& offset)
         throw std::runtime_error("Problem seeking on remote object");
 }
 
+void media::PlayerStub::equalizer_set_band(int band, double gain) 
+{
+    MH_INFO("not implemented");
+}
+
+
 void media::PlayerStub::stop()
 {
     auto op = d->object->transact_method<mpris::Player::Stop, void>();

--- a/src/core/media/player_stub.h
+++ b/src/core/media/player_stub.h
@@ -62,6 +62,7 @@ class PlayerStub : public Player
     virtual void pause();
     virtual void seek_to(const std::chrono::microseconds& offset);
     virtual void stop();
+    virtual void equalizer_set_band(int band, double gain);
 
     virtual const core::Property<bool>& can_play() const;
     virtual const core::Property<bool>& can_pause() const;

--- a/src/core/media/service_implementation.cpp
+++ b/src/core/media/service_implementation.cpp
@@ -362,6 +362,20 @@ void media::ServiceImplementation::resume_multimedia_session()
     }
 }
 
+void media::ServiceImplementation::equalizer_set_band(int band, double gain) {
+    d->configuration.player_store->enumerate_players([this, band, gain]
+            (const media::Player::PlayerKey& key,
+             const std::shared_ptr<media::Player>& player)
+    {
+        // Only set eualizer if player has an audio stream role set to multimedia
+        if (player->audio_stream_role() == media::Player::multimedia)
+        {
+            MH_INFO("Set Equalizer Band for Player with key: %d", key);
+            player->equalizer_set_band(band, gain);
+        }
+    });
+}
+
 const core::Signal<void>& media::ServiceImplementation::service_disconnected() const
 {
     throw std::runtime_error("This signal is only accessible from the ServiceStub");

--- a/src/core/media/service_implementation.cpp
+++ b/src/core/media/service_implementation.cpp
@@ -96,6 +96,7 @@ struct media::ServiceImplementation::Private
     std::list<std::pair<media::Player::PlayerKey, bool>> paused_sessions;
 
     map<int, double> equalizer_bands;
+
 };
 
 media::ServiceImplementation::ServiceImplementation(const Configuration& configuration)
@@ -394,6 +395,13 @@ void media::ServiceImplementation::equalizer_set_band(int band, double gain) {
             player->equalizer_set_band(band, gain);
         }
     });
+}
+
+const core::Signal<media::Service::EqualizerBand>& media::ServiceImplementation::equalizer_band_changed() const
+{
+    throw std::runtime_error("This signal is not to used from here");
+    static const core::Signal<media::Service::EqualizerBand> s;
+    return s;
 }
 
 const core::Signal<void>& media::ServiceImplementation::service_disconnected() const

--- a/src/core/media/service_implementation.h
+++ b/src/core/media/service_implementation.h
@@ -50,6 +50,7 @@ public:
     std::shared_ptr<Player> create_fixed_session(const std::string& name, const Player::Configuration&);
     std::shared_ptr<Player> resume_session(Player::PlayerKey key);
     void pause_other_sessions(Player::PlayerKey key);
+    std::map<int, double>& equalizer_get_bands();
     void equalizer_set_band(int band, double gain);
 
     const core::Signal<void>& service_disconnected() const;

--- a/src/core/media/service_implementation.h
+++ b/src/core/media/service_implementation.h
@@ -50,6 +50,7 @@ public:
     std::shared_ptr<Player> create_fixed_session(const std::string& name, const Player::Configuration&);
     std::shared_ptr<Player> resume_session(Player::PlayerKey key);
     void pause_other_sessions(Player::PlayerKey key);
+    void equalizer_set_band(int band, double gain);
 
     const core::Signal<void>& service_disconnected() const;
     const core::Signal<void>& service_reconnected() const;

--- a/src/core/media/service_implementation.h
+++ b/src/core/media/service_implementation.h
@@ -21,6 +21,7 @@
 
 #include "service_skeleton.h"
 #include "external_services.h"
+#include "mpris/service.h"
 
 namespace core
 {
@@ -52,6 +53,7 @@ public:
     void pause_other_sessions(Player::PlayerKey key);
     std::map<int, double>& equalizer_get_bands();
     void equalizer_set_band(int band, double gain);
+    const core::Signal<EqualizerBand>& equalizer_band_changed() const;
 
     const core::Signal<void>& service_disconnected() const;
     const core::Signal<void>& service_reconnected() const;
@@ -63,6 +65,7 @@ private:
 
     struct Private;
     std::shared_ptr<Private> d;
+
 };
 }
 }

--- a/src/core/media/service_skeleton.cpp
+++ b/src/core/media/service_skeleton.cpp
@@ -506,7 +506,7 @@ struct media::ServiceSkeleton::Private
         core::dbus::Message::Ptr reply;
         try {
             int band = 0;    //   0 .. 9
-            double gain = 0; // -24 .. 24
+            double gain = 0; // -24 .. 12
 
             msg->reader() >> band >> gain;
 

--- a/src/core/media/service_skeleton.cpp
+++ b/src/core/media/service_skeleton.cpp
@@ -508,8 +508,7 @@ struct media::ServiceSkeleton::Private
             int band = 0;    //   0 .. 9
             double gain = 0; // -24 .. 24
 
-            msg->reader() >> band;
-            msg->reader() >> gain;
+            msg->reader() >> band >> gain;
 
             impl->equalizer_set_band(band, gain);
             reply = dbus::Message::make_method_return(msg);

--- a/src/core/media/service_skeleton.h
+++ b/src/core/media/service_skeleton.h
@@ -63,6 +63,7 @@ public:
     bool is_current_player(Player::PlayerKey key) const;
     void reset_current_player();
     void pause_other_sessions(Player::PlayerKey key);
+    std::map<int, double>& equalizer_get_bands();
     void equalizer_set_band(int band, double gain);
 
     void run();

--- a/src/core/media/service_skeleton.h
+++ b/src/core/media/service_skeleton.h
@@ -63,6 +63,7 @@ public:
     bool is_current_player(Player::PlayerKey key) const;
     void reset_current_player();
     void pause_other_sessions(Player::PlayerKey key);
+    void equalizer_set_band(int band, double gain);
 
     void run();
     void stop();

--- a/src/core/media/service_skeleton.h
+++ b/src/core/media/service_skeleton.h
@@ -65,6 +65,7 @@ public:
     void pause_other_sessions(Player::PlayerKey key);
     std::map<int, double>& equalizer_get_bands();
     void equalizer_set_band(int band, double gain);
+    virtual const core::Signal<EqualizerBand>& equalizer_band_changed() const;
 
     void run();
     void stop();

--- a/src/core/media/service_stub.cpp
+++ b/src/core/media/service_stub.cpp
@@ -172,6 +172,10 @@ void media::ServiceStub::pause_other_sessions(media::Player::PlayerKey key)
         throw std::runtime_error("Problem pausing other sessions: " + op.error());
 }
 
+std::map<int, double>& media::ServiceStub::equalizer_get_bands() {
+  MH_INFO("not implemented");
+}
+
 void media::ServiceStub::equalizer_set_band(int band, double gain) {
   MH_INFO("not implemented");
 }

--- a/src/core/media/service_stub.cpp
+++ b/src/core/media/service_stub.cpp
@@ -172,6 +172,10 @@ void media::ServiceStub::pause_other_sessions(media::Player::PlayerKey key)
         throw std::runtime_error("Problem pausing other sessions: " + op.error());
 }
 
+void media::ServiceStub::equalizer_set_band(int band, double gain) {
+  MH_INFO("not implemented");
+}
+
 const core::Signal<void>& media::ServiceStub::service_disconnected() const
 {
     return signals.service_disconnected;

--- a/src/core/media/service_stub.cpp
+++ b/src/core/media/service_stub.cpp
@@ -180,6 +180,13 @@ void media::ServiceStub::equalizer_set_band(int band, double gain) {
   MH_INFO("not implemented");
 }
 
+const core::Signal<media::Service::EqualizerBand>& media::ServiceStub::equalizer_band_changed() const
+{
+    throw std::runtime_error("This signal is not implemented");
+    static const core::Signal<media::Service::EqualizerBand> s;
+    return s;
+}
+
 const core::Signal<void>& media::ServiceStub::service_disconnected() const
 {
     return signals.service_disconnected;

--- a/src/core/media/service_stub.h
+++ b/src/core/media/service_stub.h
@@ -49,6 +49,7 @@ class ServiceStub : public core::dbus::Stub<core::ubuntu::media::Service>
     std::shared_ptr<Player> create_fixed_session(const std::string& name, const Player::Configuration&);
     std::shared_ptr<Player> resume_session(Player::PlayerKey key);
     void pause_other_sessions(Player::PlayerKey key);
+    std::map<int, double>& equalizer_get_bands();
     void equalizer_set_band(int band, double gain);
 
     virtual const core::Signal<void>& service_disconnected() const;

--- a/src/core/media/service_stub.h
+++ b/src/core/media/service_stub.h
@@ -49,6 +49,7 @@ class ServiceStub : public core::dbus::Stub<core::ubuntu::media::Service>
     std::shared_ptr<Player> create_fixed_session(const std::string& name, const Player::Configuration&);
     std::shared_ptr<Player> resume_session(Player::PlayerKey key);
     void pause_other_sessions(Player::PlayerKey key);
+    void equalizer_set_band(int band, double gain);
 
     virtual const core::Signal<void>& service_disconnected() const;
     virtual const core::Signal<void>& service_reconnected() const;

--- a/src/core/media/service_stub.h
+++ b/src/core/media/service_stub.h
@@ -51,6 +51,7 @@ class ServiceStub : public core::dbus::Stub<core::ubuntu::media::Service>
     void pause_other_sessions(Player::PlayerKey key);
     std::map<int, double>& equalizer_get_bands();
     void equalizer_set_band(int band, double gain);
+    virtual const core::Signal<EqualizerBand>& equalizer_band_changed() const;
 
     virtual const core::Signal<void>& service_disconnected() const;
     virtual const core::Signal<void>& service_reconnected() const;


### PR DESCRIPTION
Adds the gstreamer 10 bands equalizer see [here](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-good/html/gst-plugins-good-plugins-equalizer-10bands.html).

Can  be controlled using dbus:
```
dbus-send --session --print-reply --type=method_call --dest=core.ubuntu.media.Service /core/ubuntu/media/Service core.ubuntu.media.Service.EqualizerSetBand int32:8 double:0
dbus-send --session --print-reply --type=method_call --dest=core.ubuntu.media.Service /core/ubuntu/media/Service core.ubuntu.media.Service.EqualizerGetBands

``` 

Only works and tested with audio.   