### PR TITLE
service: simplify logic of moving to next track

### DIFF
--- a/tests/service/functional/MediaHub.py
+++ b/tests/service/functional/MediaHub.py
@@ -97,6 +97,9 @@ class Player(object):
         for cb in self.__signal_callbacks:
             cb(signal_name, *args)
 
+    def clear_signals(self):
+        self.signals = []
+
     def wait_for_signal(self, name, *args, timeout=3000):
         match = [name, *args]
         if match in self.signals:
@@ -124,6 +127,9 @@ class Player(object):
         self.loop.run()
         self.unsubscribe_properties_changed(check_value)
         return True if self.props.get(name) == value else False
+
+    def set_prop(self, name, value):
+        return self.__properties.Set(self.interface_name, name, value)
 
     def get_prop(self, name):
         return self.__properties.Get(self.interface_name, name)

--- a/tests/service/functional/test_media_hub_service.py
+++ b/tests/service/functional/test_media_hub_service.py
@@ -270,3 +270,24 @@ class TestMediaHub:
         # Next/Prev properties will swap:
         assert player.wait_for_prop('CanGoNext', False)
         assert player.wait_for_prop('CanGoPrevious', True)
+
+    def test_loop(self, bus_obj, media_hub_service_full, data_path):
+        media_hub = MediaHub.Service(bus_obj)
+        (object_path, uuid) = media_hub.create_session()
+        player = MediaHub.Player(bus_obj, object_path)
+
+        player.set_prop('LoopStatus', dbus.String('Track', variant_level=1))
+        assert player.get_prop('LoopStatus') == 'Track'
+        assert player.get_prop('TypedLoopStatus') == 1
+
+        audio_file = 'file://' + str(data_path.joinpath('test-audio.ogg'))
+        player.open_uri(audio_file)
+
+        player.play()
+        assert player.wait_for_prop('PlaybackStatus', 'Playing')
+        assert player.wait_for_signal('AboutToFinish')
+        assert player.wait_for_prop('PlaybackStatus', 'Stopped')
+        player.clear_signals()
+        assert player.wait_for_prop('PlaybackStatus', 'Playing')
+        assert player.wait_for_signal('AboutToFinish')
+        assert player.wait_for_prop('PlaybackStatus', 'Stopped')


### PR DESCRIPTION
The previous implementation was overly complicated (possibly because of
multithreading), spanning over two different code paths.

Now we always respect the goToTrack() signal. This fixes an issue when
the playback loop was set to a single track.

Fixes: https://github.com/ubports/media-hub/issues/33


Please take special care when testing this: the change being applied is quite delicate, so it's desirable to have it tested carefully.
