### PR TITLE
Test track reset

### DIFF
--- a/tests/service/functional/MediaHub.py
+++ b/tests/service/functional/MediaHub.py
@@ -116,7 +116,7 @@ class Player(object):
         return True if match in self.signals else False
 
     def wait_for_prop(self, name, value, timeout=3000):
-        if self.props.get(name) == value:
+        if self.get_prop(name) == value:
             return True
         timer_id = GLib.timeout_add(timeout, self.loop.quit)
         def check_value(interface, changed, invalidated):

--- a/tests/service/functional/MediaHub.py
+++ b/tests/service/functional/MediaHub.py
@@ -143,6 +143,9 @@ class Player(object):
     def play(self):
         self.__player.Play()
 
+    def pause(self):
+        self.__player.Pause()
+
     def on_properties_changed(self, callback):
         self.__prop_callbacks.append(callback)
 
@@ -168,6 +171,9 @@ class TrackList(object):
 
     def add_track(self, track_uri, position=End, set_as_current=False):
         self.__track_list.AddTrack(track_uri, position, set_as_current)
+
+    def reset(self):
+        self.__track_list.Reset()
 
 
 class MprisPlayer(Player):


### PR DESCRIPTION
I wrote this in order to reproduce https://github.com/ubports/media-hub/issues/35, but as a matter of fact, the bug is not triggered.

Still, I think it's good to merge this, because it's a valid test that increases our code coverage. It touches only the python test code, so it should be safe to merge.