### PR TITLE
tests: make track test more stable

### DIFF
--- a/tests/service/functional/test_media_hub_service.py
+++ b/tests/service/functional/test_media_hub_service.py
@@ -267,6 +267,7 @@ class TestMediaHub:
         assert player.wait_for_prop('PlaybackStatus', 'Playing')
         # The first track will finish soon
         assert player.wait_for_signal('AboutToFinish')
+        assert player.wait_for_prop('PlaybackStatus', 'Stopped', timeout=5000)
         # Next/Prev properties will swap:
         assert player.wait_for_prop('CanGoNext', False)
         assert player.wait_for_prop('CanGoPrevious', True)


### PR DESCRIPTION
The AboutToFinish signal is emitted 2-3 seconds before the actual
termination of the track. Since our default timeout for verifying
property changes is 3000ms, there's a concrete risk tha our assertion
will fail.

Instead of just increasing the timeout in the property assertion, add
one more check to wait for the playback status to become "stopped",
which will happen when the track is effectively finish. We set this
timeout to 5000ms because, as said before, about 2 to 3 seconds will be
taken for effectively waiting for the song to finish, and another 2 can
be spent while D-Bus delivers the signal, if the machine is busy.