### PR TITLE
service: properly update output information

### DIFF
--- a/src/core/media/audio/pulse_audio_output_observer.cpp
+++ b/src/core/media/audio/pulse_audio_output_observer.cpp
@@ -320,7 +320,7 @@ struct audio::PulseAudioOutputObserver::Private
             const bool available = pa::is_port_available_on_sink(info, std::get<0>(element));
             if (available)
             {
-                std::get<1>(element) = audio::OutputState::Earpiece;
+                setOutputState(element, audio::OutputState::Earpiece);
                 continue;
             }
 


### PR DESCRIPTION
We need to emit the output state change signal when pulseaudio reports
that the active output changed. This is done by calling
setOutputState(), but one invocation of this function was missed during
the porting to Qt.

Fixes: https://github.com/ubports/ubuntu-touch/issues/1782

Tests are still missing, but they won't come soon as I don't know how to synthesize ports events with pulseaudio. I do recommend merging this after some manual testing, and open an issue to have functional tests for this.