### PR TITLE
AppArmor: allow product and system paths for camera_click.ogg

### DIFF
--- a/debian/usr.bin.media-hub-server
+++ b/debian/usr.bin.media-hub-server
@@ -104,6 +104,7 @@
   /**/ r,
 
   # camera click
+  /{,android/}product/media/audio/ui/camera_click.ogg r,
   /{,android/}system/media/audio/ui/camera_click.ogg r,
 
   # custom sounds


### PR DESCRIPTION
Newer Android versions place the media files in /product/media
instead of /system/media.

Change-Id: I12f272c70f38afaff7d8dfe398a58ea89f48eff8
Signed-off-by: Alexander Martinz <alex@amartinz.at>