### PR TITLE
service: don't release the wakelock when switching tracks

### DIFF
--- a/src/core/media/player_implementation.cpp
+++ b/src/core/media/player_implementation.cpp
@@ -96,6 +96,10 @@ public:
 
             MH_INFO("Requesting power state");
             request_power_state();
+            /* If this is part of a playlist, the wakelock timer was started
+             * when the previous track completed. So, we must stop it now or it
+             * will release the power state while we are playing. */
+            m_wakeLockTimer.stop();
             break;
         }
         case Engine::State::stopped:

--- a/tests/service/functional/conftest.py
+++ b/tests/service/functional/conftest.py
@@ -16,7 +16,12 @@ dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
 
 @pytest.fixture(scope="function")
-def media_hub_service(request):
+def media_hub_wakelock_timeout(request):
+    return '0'  # milliseconds
+
+
+@pytest.fixture(scope="function")
+def media_hub_service(request, media_hub_wakelock_timeout):
     """ Spawn a new media-hub service instance
     """
     service_name = "core.ubuntu.media.Service"
@@ -33,7 +38,7 @@ def media_hub_service(request):
         "mock.org.freedesktop.dbus"
     environment['CORE_UBUNTU_MEDIA_SERVICE_AUDIO_SINK_NAME'] = 'fakesink'
     environment['CORE_UBUNTU_MEDIA_SERVICE_VIDEO_SINK_NAME'] = 'fakesink'
-    environment['MEDIA_HUB_WAKELOCK_TIMEOUT'] = '0'  # milliseconds
+    environment['MEDIA_HUB_WAKELOCK_TIMEOUT'] = media_hub_wakelock_timeout
 
     # Spawn the service, and wait for it to appear on the bus
     args = [os.environ['SERVICE_BINARY']]


### PR DESCRIPTION
When a track finishes playing, the wakelock timer is started in order to
release the wakelock. However, if there's another track playing, we must
cancel the timer.

Fixes: https://github.com/ubports/ubuntu-touch/issues/1482
Fixes https://github.com/ubports/ubuntu-touch/issues/1798