### PR TITLE
lib: fix unmarshalling of D-Bus property map

### DIFF
--- a/src/lib/MediaHub/track_list.cpp
+++ b/src/lib/MediaHub/track_list.cpp
@@ -88,7 +88,8 @@ DBusTrackList::DBusTrackList(const QDBusConnection &conn,
         qWarning() << "Cannot get tracklist properties:" <<
             reply.errorMessage();
     } else {
-        d->initialize(reply.arguments().first().toMap());
+        QDBusArgument arg = reply.arguments().first().value<QDBusArgument>();
+        d->initialize(qdbus_cast<QVariantMap>(arg));
     }
 }
 


### PR DESCRIPTION
This is the same code that we use in the Player class, but for some
reason forgot to update the TrackList.

Fixes: https://github.com/ubports/ubuntu-touch/issues/1899